### PR TITLE
Fix redundant read.

### DIFF
--- a/src/database/MySqlCrud.java
+++ b/src/database/MySqlCrud.java
@@ -75,14 +75,9 @@ public class MySqlCrud extends StorageCrud {
 
     @Override
     public boolean createBundle(Bundle bundle) {
-        List<String> bundleKeys = bundle.getAttributeKeys();
-        List<String> bundleData = bundle.getAllAttributes();
-        List<DataType> bundleTypes = bundle.getAttributeDataTypes();
-
-        // remove the bundleId, since we do not need that to create a row
-        bundleKeys.remove(0);
-        bundleData.remove(0);
-        bundleTypes.remove(0);
+        List<String> bundleKeys = bundle.getAttributeKeysNoId();
+        List<String> bundleData = bundle.getAllAttributesNoId();
+        List<DataType> bundleTypes = bundle.getAttributeDataTypesNoId();
 
         // since nobody else should be writing at the same time, we can do this (single
         // threaded)
@@ -133,12 +128,9 @@ public class MySqlCrud extends StorageCrud {
     public boolean createCategory(Category category) {
         // This could be done using a hash map instead of two lists, it works for now
         // though
-        List<String> keys = category.getAttributeKeys();
-        keys.remove(0);
-        List<String> data = category.getAllAttributes();
-        data.remove(0);
-        List<DataType> types = category.getAttributeDataTypes();
-        types.remove(0);
+        List<String> keys = category.getAttributeKeysNoId();
+        List<String> data = category.getAllAttributesNoId();
+        List<DataType> types = category.getAttributeDataTypesNoId();
         return storageService.create(Category.TABLE_NAME, data, keys, types);
     }
 

--- a/src/database/MySqlCrud.java
+++ b/src/database/MySqlCrud.java
@@ -66,32 +66,11 @@ public class MySqlCrud extends StorageCrud {
      */
     @Override
     public boolean createItem(Item item) {
-
-        // Remove ID keys as they're auto-generated
-        List<String> keys = item.getAttributeKeys();
-        keys.remove(0);
-        List<String> data = item.getAllAttributes();
-        data.remove(0);
-        List<DataType> types = item.getAttributeDataTypes();
-        types.remove(0);
+        List<String> keys = item.getAttributeKeysNoId();
+        List<String> data = item.getAllAttributesNoId();
+        List<DataType> types = item.getAttributeDataTypesNoId();
         // Create the item in the database
-        boolean created = storageService.create(Item.TABLE_NAME, data, keys, types);
-
-        if (created) {
-            // Retrieve the item we just inserted using its temporary SKU and fix it
-            List<String> idKey = new ArrayList<>();
-            idKey.add(Item.ITEM_ID_KEY);
-
-            List<Map<String, String>> result = storageService.readSearchRow(Item.TABLE_NAME, idKey, Item.SKU_KEY,
-                    item.getSku(), DataType.STRING);
-
-            if (!result.isEmpty()) {
-                int generatedId = Integer.parseInt(result.get(0).get(Item.ITEM_ID_KEY));
-                item.setItemId(generatedId);
-            }
-        }
-
-        return created;
+        return storageService.create(Item.TABLE_NAME, data, keys, types);
     }
 
     @Override


### PR DESCRIPTION
Removes redundant and bad read from `createItem()` in MySqlCrud.
- Cleaning up other methods to use new methods to get lists without ID's.