### PR TITLE
Add transactions.

### DIFF
--- a/src/database/MySql.java
+++ b/src/database/MySql.java
@@ -26,6 +26,9 @@ public class MySql implements Storage {
         // we don't want to handle this exception ourselves, so the user can decide what
         // to do if this fails
         connection = DriverManager.getConnection(url, username, password);
+
+        // so the database doesn't have problems with auto_increment not being set
+        performPreparedStatement("set global information_schema_stats_expiry=0");
     }
 
     /**

--- a/src/database/MySql.java
+++ b/src/database/MySql.java
@@ -29,6 +29,7 @@ public class MySql implements Storage {
 
         // so the database doesn't have problems with auto_increment not being set
         performPreparedStatement("set global information_schema_stats_expiry=0");
+        performPreparedStatement("set autocommit=0");
     }
 
     /**
@@ -389,6 +390,39 @@ public class MySql implements Storage {
             formattedData = data; // For other types, keep as is
         }
         return formattedData;
+    }
+
+    @Override
+    public boolean startTransaction() {
+        try {
+            performPreparedStatement("start transaction");
+        } catch (SQLException sqle) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean commitTransaction() {
+        try {
+            performPreparedStatement("commit");
+        } catch (SQLException sqle) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean abortTransaction() {
+        try {
+            performPreparedStatement("rollback");
+        } catch (SQLException sqle) {
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/src/database/MySqlCrud.java
+++ b/src/database/MySqlCrud.java
@@ -70,8 +70,11 @@ public class MySqlCrud extends StorageCrud {
         }
         // Create the item in the database
         boolean result = storageService.create(Item.TABLE_NAME, data, keys, types);
-
-        storageService.commitTransaction();
+        if (result) {
+            storageService.commitTransaction();
+        } else {
+            storageService.abortTransaction();
+        }
         return result;
     }
 
@@ -144,7 +147,11 @@ public class MySqlCrud extends StorageCrud {
         List<String> data = category.getAllAttributesNoId();
         List<DataType> types = category.getAttributeDataTypesNoId();
         boolean result = storageService.create(Category.TABLE_NAME, data, keys, types);
-        storageService.commitTransaction();
+        if (result) {
+            storageService.commitTransaction();
+        } else {
+            storageService.abortTransaction();
+        }
         return result;
     }
 
@@ -365,7 +372,11 @@ public class MySqlCrud extends StorageCrud {
         List<String> data = item.getAllAttributes();
         List<DataType> types = item.getAttributeDataTypes();
         boolean result = storageService.update(Item.TABLE_NAME, data, keys, types);
-        storageService.commitTransaction();
+        if (result) {
+            storageService.commitTransaction();
+        } else {
+            storageService.abortTransaction();
+        }
         return result;
     }
 
@@ -375,7 +386,11 @@ public class MySqlCrud extends StorageCrud {
             return false; // fail to start transaction
         }
         boolean result = storageService.update(Category.TABLE_NAME, categoryData, categoryKeys, categoryTypes);
-        storageService.commitTransaction();
+        if (result) {
+            storageService.commitTransaction();
+        } else {
+            storageService.abortTransaction();
+        }
         return result;
     }
 

--- a/src/database/MySqlCrud.java
+++ b/src/database/MySqlCrud.java
@@ -42,11 +42,6 @@ public class MySqlCrud extends StorageCrud {
         // create them
     }
 
-    private void setup() {
-        // set autocommit = 0;
-        // set global information_schema_stats_expiry=0;
-    }
-
     /**
      * Find the next incremented ID from the provided table (Item, Category).
      * 
@@ -69,12 +64,23 @@ public class MySqlCrud extends StorageCrud {
         List<String> keys = item.getAttributeKeysNoId();
         List<String> data = item.getAllAttributesNoId();
         List<DataType> types = item.getAttributeDataTypesNoId();
+
+        if (!storageService.startTransaction()) {
+            return false; // fail to start transaction
+        }
         // Create the item in the database
-        return storageService.create(Item.TABLE_NAME, data, keys, types);
+        boolean result = storageService.create(Item.TABLE_NAME, data, keys, types);
+
+        storageService.commitTransaction();
+        return result;
     }
 
     @Override
     public boolean createBundle(Bundle bundle) {
+        if (!storageService.startTransaction()) {
+            return false; // fail to start transaction
+        }
+
         List<String> bundleKeys = bundle.getAttributeKeysNoId();
         List<String> bundleData = bundle.getAllAttributesNoId();
         List<DataType> bundleTypes = bundle.getAttributeDataTypesNoId();
@@ -83,6 +89,7 @@ public class MySqlCrud extends StorageCrud {
         // threaded)
         int newBundleId = storageService.getNextIncrementedId(Bundle.TABLE_NAME);
         if (!storageService.create(Bundle.TABLE_NAME, bundleData, bundleKeys, bundleTypes)) {
+            storageService.abortTransaction();
             return false; // failure
         }
 
@@ -108,10 +115,12 @@ public class MySqlCrud extends StorageCrud {
             // create the entry for this item, bundle pair
             if (!storageService.create(Bundle.ASSOCIATION_TABLE_NAME, itemBundleData, itemBundleKeys,
                     itemBundleTypes)) {
+                storageService.abortTransaction();
                 return false; // failure
             }
         }
 
+        storageService.commitTransaction();
         return true; // success
     }
 
@@ -126,12 +135,17 @@ public class MySqlCrud extends StorageCrud {
      */
     @Override
     public boolean createCategory(Category category) {
+        if (!storageService.startTransaction()) {
+            return false; // fail to start transaction
+        }
         // This could be done using a hash map instead of two lists, it works for now
         // though
         List<String> keys = category.getAttributeKeysNoId();
         List<String> data = category.getAllAttributesNoId();
         List<DataType> types = category.getAttributeDataTypesNoId();
-        return storageService.create(Category.TABLE_NAME, data, keys, types);
+        boolean result = storageService.create(Category.TABLE_NAME, data, keys, types);
+        storageService.commitTransaction();
+        return result;
     }
 
     @Override
@@ -280,12 +294,6 @@ public class MySqlCrud extends StorageCrud {
     }
 
     @Override
-    public Bundle readBundle(int bundleId) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'readBundle'");
-    }
-
-    @Override
     public Category readCategory(int categoryId) {
         Map<String, String> categoryData = this.storageService.read("Category", categoryId,
                 ObjectService.getItemKeys());
@@ -350,22 +358,25 @@ public class MySqlCrud extends StorageCrud {
 
     @Override
     public boolean updateItem(Item item) {
+        if (!storageService.startTransaction()) {
+            return false; // fail to start transaction
+        }
         List<String> keys = item.getAttributeKeys();
         List<String> data = item.getAllAttributes();
         List<DataType> types = item.getAttributeDataTypes();
-        return storageService.update(Item.TABLE_NAME, data, keys, types);
-    }
-
-    @Override
-    public boolean updateBundle(Bundle bundle) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'updateBundle'");
+        boolean result = storageService.update(Item.TABLE_NAME, data, keys, types);
+        storageService.commitTransaction();
+        return result;
     }
 
     @Override
     public boolean updateCategory(List<String> categoryData, List<String> categoryKeys, List<DataType> categoryTypes) {
-
-        return storageService.update(Category.TABLE_NAME, categoryData, categoryKeys, categoryTypes);
+        if (!storageService.startTransaction()) {
+            return false; // fail to start transaction
+        }
+        boolean result = storageService.update(Category.TABLE_NAME, categoryData, categoryKeys, categoryTypes);
+        storageService.commitTransaction();
+        return result;
     }
 
     /**

--- a/src/database/Storage.java
+++ b/src/database/Storage.java
@@ -64,5 +64,41 @@ public interface Storage extends AutoCloseable {
     public List<Map<String, String>> readSearchRow(String tableName, List<String> keys, String haystackKey,
             String needleValue, DataType needleType);
 
+    /**
+     * Creates an entry to a table.
+     * 
+     * @param tableName The table name.
+     * @param data      The data to put into the database.
+     * @param keys      The keys of the data to put into the database. NOTE: should
+     *                  have the same size and have the same data in the same order
+     *                  as data.
+     * @param dataTypes The datatypes of the data to put into the database. NOTE:
+     *                  should have the same size and have the same data in the same
+     *                  order as data.
+     * 
+     * @return True if successful, false otherwise.
+     */
     public boolean create(String tableName, List<String> data, List<String> keys, List<DataType> dataTypes);
+
+    /**
+     * Start database transaction.
+     * 
+     * @return True if successful, false otherwise.
+     */
+    public boolean startTransaction();
+
+    /**
+     * Commit database transaction.
+     * 
+     * @return True if successful, false otherwise.
+     */
+    public boolean commitTransaction();
+
+    /**
+     * Abort database transaction.
+     * 
+     * @return True if successful, false otherwise.
+     */
+    public boolean abortTransaction();
+
 }

--- a/src/database/StorageCrud.java
+++ b/src/database/StorageCrud.java
@@ -109,14 +109,6 @@ public abstract class StorageCrud {
     public abstract List<Category> readAllCategories();
 
     /**
-     * Reads a Bundle in Storage from the provided ID.
-     * 
-     * @param bundleId The object ID to search for in Storage.
-     * @return The read Bundle object, or null upon error.
-     */
-    public abstract Bundle readBundle(int bundleId);
-
-    /**
      * Reads a Category in Storage from the provided ID.
      * 
      * @param categoryId The object ID to search for in Storage.
@@ -131,14 +123,6 @@ public abstract class StorageCrud {
      * @return True upon success, false upon failure.
      */
     public abstract boolean updateItem(Item item);
-
-    /**
-     * Updates a Bundle in Storage from the provided object.
-     * 
-     * @param bundle The new object to put in place of the old.
-     * @return True upon success, false upon failure.
-     */
-    public abstract boolean updateBundle(Bundle bundle);
 
     /**
      * Updates a Category in storage from the provided object


### PR DESCRIPTION
Adds ability to perform transactions when doing creates or updates (to prevent the database from being left in an uncertain state!)
- Remove StorageCrud methods that do not have a use case.
- Add transactions where needed.
- Add setup of the database so that auto increment is always immediately updated.
- Add setup so the database does not autocommit.