### PR TITLE
Minor database fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.zip
 bin/
 build/
+*.csv
+*.txt

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,20 @@ List of TODO info.
 
 ## Database
 
+### Setting up MySQL Database
+
+The MySQL database and user can be set up with:
+
+```sql
+create database warehelper; -- create the database
+
+create user 'testuser'@'localhost' identified by 'password'; -- create test user
+
+grant all privileges on warehelper.* to 'testuser'@'localhost' with grant option; -- grant all privileges to test user
+
+flush privileges;
+```
+
 ### How to Create Tables for Warehelper
 
 Category table creation:

--- a/src/database/MySqlCrud.java
+++ b/src/database/MySqlCrud.java
@@ -418,19 +418,48 @@ public class MySqlCrud extends StorageCrud {
      */
     @Override
     public boolean deleteItem(int itemId) {
+        if (!storageService.startTransaction()) {
+            return false; // fail to start transaction
+        }
         // Delete the item from the "Item" table where the ItemId matches the provided
         // itemId.
-        return storageService.delete("Item", "ItemId", itemId);
+        boolean result = storageService.delete("Item", "ItemId", itemId);
+        if (result) {
+            storageService.commitTransaction();
+        } else {
+            storageService.abortTransaction();
+        }
+        return result;
     }
 
     @Override
     public boolean deleteBundle(int bundleId) {
-        return storageService.delete(Bundle.TABLE_NAME, Bundle.BUNDLE_ID_KEY, bundleId);
+        if (!storageService.startTransaction()) {
+            return false; // fail to start transaction
+        }
+
+        boolean result = storageService.delete(Bundle.TABLE_NAME, Bundle.BUNDLE_ID_KEY, bundleId);
+        if (result) {
+            storageService.commitTransaction();
+        } else {
+            storageService.abortTransaction();
+        }
+        return result;
     }
 
     @Override
     public boolean deleteCategory(int categoryId) {
-        return storageService.delete(Category.TABLE_NAME, Category.CATEGORY_ID_KEY, categoryId);
+        if (!storageService.startTransaction()) {
+            return false; // fail to start transaction
+        }
+
+        boolean result = storageService.delete(Category.TABLE_NAME, Category.CATEGORY_ID_KEY, categoryId);
+        if (result) {
+            storageService.commitTransaction();
+        } else {
+            storageService.abortTransaction();
+        }
+        return result;
     }
 
 }

--- a/src/database/MySqlCrud.java
+++ b/src/database/MySqlCrud.java
@@ -198,6 +198,10 @@ public class MySqlCrud extends StorageCrud {
 
     @Override
     public List<Item> readAllItems() throws RuntimeException {
+        if (!storageService.startTransaction()) {
+            return new ArrayList<>(); // fail to start transaction
+        }
+
         List<Item> items = new ArrayList<>();
 
         List<String> keys = ObjectService.getItemKeys();
@@ -216,6 +220,7 @@ public class MySqlCrud extends StorageCrud {
         for (int i = 0; i < itemMaps.size(); i++) {
             items.add(ObjectService.createItem(itemMaps.get(i), categoryMaps.get(i)));
         }
+        storageService.commitTransaction();
 
         return items;
     }

--- a/src/tests/RetrieveInventoryTest.java
+++ b/src/tests/RetrieveInventoryTest.java
@@ -72,6 +72,8 @@ public class RetrieveInventoryTest {
 
         // clear expected items
         expectedItems.clear();
+        // commit to storage, since it did not commit these changes yet
+        storage.commitTransaction();
     }
 
     /**
@@ -111,7 +113,8 @@ public class RetrieveInventoryTest {
 
         // create the item
         assertTrue(storageCrud.createItem(firstItem));
-
+        // commit to storage, since it did not commit these changes yet
+        storage.commitTransaction();
     }
 
     /**

--- a/src/tests/RetrieveInventoryTest.java
+++ b/src/tests/RetrieveInventoryTest.java
@@ -105,8 +105,13 @@ public class RetrieveInventoryTest {
                 Date.valueOf(formattedDate), Date.valueOf(formattedDate), 10, 23, 0.0);
         expectedItems.add(firstItem);
 
+        // get the ID
+        int itemId = storageCrud.getNextId(Item.TABLE_NAME);
+        firstItem.setItemId(itemId);
+
         // create the item
         assertTrue(storageCrud.createItem(firstItem));
+
     }
 
     /**

--- a/src/tests/RetrieveInventoryTest.java
+++ b/src/tests/RetrieveInventoryTest.java
@@ -42,7 +42,7 @@ public class RetrieveInventoryTest {
     static {
         try {
             storageCrud = new MySqlCrud();
-            storage = new MySql(MySqlCrud.url, MySqlCrud.username, MySqlCrud.password);
+            storage = new MySql(MySqlCrud.url, MySqlCrud.username, MySqlCrud.password, MySqlCrud.tableQueries);
         } catch (SQLException sqle) {
             throw new RuntimeException("Could not initialize MySqlCrud or MySql");
         }

--- a/src/tests/RetrieveInventoryTest.java
+++ b/src/tests/RetrieveInventoryTest.java
@@ -260,11 +260,7 @@ public class RetrieveInventoryTest {
             List<Item> items = storageCrud.readAllItems();
 
             // check that they're all equal
-            assertEquals(items.size(), expectedItems.size());
-            for (int i = 0; i < items.size(); i++) {
-                assertEquals(expectedItems.get(i), items.get(i));
-            }
-
+            assertEquals(items, expectedItems);
             deleteAllItemsAndCategories();
         } catch (Exception e) {
             fail("Error reading single item with MySqlCrud");

--- a/src/tests/RetrieveInventoryTest.java
+++ b/src/tests/RetrieveInventoryTest.java
@@ -166,6 +166,7 @@ public class RetrieveInventoryTest {
     public void test3ObjectServiceCreateItem() {
         databaseMutex.lock();
         try {
+            deleteAllItemsAndCategories();
             addFirstItem();
 
             Item theItem = expectedItems.get(0);
@@ -208,6 +209,7 @@ public class RetrieveInventoryTest {
     public void test4ObjectServiceCreateItemFail() {
         databaseMutex.lock();
         try {
+            deleteAllItemsAndCategories();
             addFirstItem();
 
             Item theItem = expectedItems.get(0);
@@ -263,6 +265,7 @@ public class RetrieveInventoryTest {
     public void test5MySqlCrudReadAllItemsSingle() {
         databaseMutex.lock();
         try {
+            deleteAllItemsAndCategories();
             addFirstItem();
 
             List<Item> items = storageCrud.readAllItems();
@@ -284,6 +287,7 @@ public class RetrieveInventoryTest {
     public void test6MySqlReadSingle() {
         databaseMutex.lock();
         try {
+            deleteAllItemsAndCategories();
             addFirstItem();
 
             // create expected Map data
@@ -308,6 +312,7 @@ public class RetrieveInventoryTest {
     public void test7MySqlReadSingleWithBadKey() {
         databaseMutex.lock();
         try {
+            deleteAllItemsAndCategories();
             addFirstItem();
 
             // create expected Map data
@@ -337,6 +342,7 @@ public class RetrieveInventoryTest {
     public void test8MySqlReadSingleEmptyInnerObjects() {
         databaseMutex.lock();
         try {
+            deleteAllItemsAndCategories();
             addFirstItem();
 
             // create expected Map data
@@ -363,6 +369,7 @@ public class RetrieveInventoryTest {
     public void test9MySqlReadSingleInnerObject() {
         databaseMutex.lock();
         try {
+            deleteAllItemsAndCategories();
             addFirstItem();
 
             // create expected Map data
@@ -392,6 +399,7 @@ public class RetrieveInventoryTest {
     public void test10ObjectServiceGetItemKeys() {
         databaseMutex.lock();
         try {
+            deleteAllItemsAndCategories();
             addFirstItem();
 
             // since we have one item


### PR DESCRIPTION
Fixes some minor problems with the database.
- Added transactions to deletes.
- Make setting `information_schema_stats_expiry=0` optional. If it fails, program will continue on and assume the database will automatically update the auto_increment (I had this problem with SKUs, but others did not).

Some test fixes:
- Fix getting back Item ID from the database.
- Fix `Storage` not being aware of creates/deletes done to the database by `StorageCrud`. Fixed by committing changes to the `Storage` once `StorageCrud` completed a database-changing operation.